### PR TITLE
fix: uniteTraceEvents behavior

### DIFF
--- a/src/__tests__/end-to-end.ts
+++ b/src/__tests__/end-to-end.ts
@@ -215,6 +215,8 @@ describe('end-to-end', () => {
     `);
   });
 
+  // TODO: write a test which will fail on the default highWaterMark
+
   test('should unite trace events', async () => {
     const file3 = tempy.file();
 

--- a/src/streams/trace-merge/transforms/TraceAnalyze.ts
+++ b/src/streams/trace-merge/transforms/TraceAnalyze.ts
@@ -1,17 +1,21 @@
-import { Transform } from 'node:stream';
+import { Writable } from 'node:stream';
 import type { TraceEvent } from 'trace-event-lib';
 import type { Resolver } from '../resolvers';
 import type { JSONLEntry } from '../../jsonl';
 
-export class TraceAnalyze extends Transform {
+export class TraceAnalyze extends Writable {
   readonly #resolver: Resolver;
 
   constructor(resolver: Resolver) {
-    super({ objectMode: true });
+    super({
+      objectMode: true,
+      highWaterMark: Number.MAX_SAFE_INTEGER,
+    });
+
     this.#resolver = resolver;
   }
 
-  _transform(
+  _write(
     chunk: unknown,
     _encoding: string,
     callback: (error?: Error | null, data?: unknown) => void,

--- a/src/streams/trace-merge/transforms/TraceMerge.ts
+++ b/src/streams/trace-merge/transforms/TraceMerge.ts
@@ -9,7 +9,11 @@ export class TraceMerge extends Transform {
   #resolver?: Resolver;
 
   constructor(resolverPromise: Promise<Resolver>) {
-    super({ objectMode: true });
+    super({
+      objectMode: true,
+      highWaterMark: Number.MAX_SAFE_INTEGER,
+    });
+
     this.#resolverPromise = resolverPromise;
   }
 


### PR DESCRIPTION
Fixes an issue spotted on [a real project](https://github.com/wix-incubator/jest-metadata) when `uniteTraceEventsToFile` just refused to work and created an empty file.

As the investigation has shown, it was caused by `highWaterMark` (default: 16), which caused the app to go idle as the streams were paused. The problem is that to unite trace events we need to analyze entire files to sort process and thread ids , so it is a two-pass algorithm.

I might change it to "two times reading" by the way, since it should be less aggressive to memory. Benchmarks will be needed.