### PR TITLE
feat: convenience methods

### DIFF
--- a/src/__tests__/end-to-end.ts
+++ b/src/__tests__/end-to-end.ts
@@ -46,8 +46,8 @@ describe('end-to-end', () => {
       }),
     });
 
-    client = wrapLogger({
-      logger: createLogger({
+    client = wrapLogger(
+      createLogger({
         name: 'client',
         streams: [
           {
@@ -58,7 +58,7 @@ describe('end-to-end', () => {
           },
         ],
       }),
-    });
+    );
   });
 
   test('should log trace events', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './noopLogger';
 export * from './traceEventStream';
 export * from './uniteTraceEvents';
 export * from './wrapLogger';

--- a/src/noopLogger/index.ts
+++ b/src/noopLogger/index.ts
@@ -1,0 +1,1 @@
+export * from './noopLogger';

--- a/src/noopLogger/noopLogger.test.ts
+++ b/src/noopLogger/noopLogger.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import type { BunyanLogLevel } from '../decorator';
+import { noopLogger } from './noopLogger';
+import { Bunyamin } from '../decorator';
+
+function wrapNoopLogger(): Bunyamin {
+  return new Bunyamin({
+    logger: noopLogger(),
+  });
+}
+
+const LOG_LEVELS: BunyanLogLevel[] = ['debug', 'error', 'fatal', 'info', 'trace', 'warn'];
+
+describe('noopLogger()', () => {
+  test('returns an object with all log methods', () => {
+    const logMethods = Object.keys(noopLogger()) as BunyanLogLevel[];
+    expect(logMethods.sort()).toEqual(LOG_LEVELS);
+  });
+
+  test.each(LOG_LEVELS)('works well with wrapped %s method invocations', (_level) => {
+    const level = _level as BunyanLogLevel;
+    const bunyamin = wrapNoopLogger();
+    const logMethod = jest.spyOn(bunyamin.logger, level);
+
+    expect(
+      bunyamin[level].complete('test message', () => {
+        bunyamin[level]('inner message');
+        return 42;
+      }),
+    ).toBe(42);
+
+    expect(logMethod).toHaveBeenCalledWith(expect.objectContaining({ ph: 'B' }), 'test message');
+    expect(logMethod).toHaveBeenCalledWith(expect.objectContaining({}), 'inner message');
+    expect(logMethod).toHaveBeenCalledWith(expect.objectContaining({ ph: 'E' }), 'test message');
+    expect(logMethod).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/noopLogger/noopLogger.ts
+++ b/src/noopLogger/noopLogger.ts
@@ -1,0 +1,16 @@
+import type { BunyanLikeLogger } from '../decorator';
+
+const noop: any = () => {
+  /* no-op */
+};
+
+export function noopLogger(_options?: any): BunyanLikeLogger {
+  return {
+    fatal: noop,
+    error: noop,
+    warn: noop,
+    info: noop,
+    debug: noop,
+    trace: noop,
+  };
+}

--- a/src/wrapLogger.ts
+++ b/src/wrapLogger.ts
@@ -5,6 +5,22 @@ export type * from './decorator';
 
 export function wrapLogger<Logger extends BunyanLikeLogger>(
   options: BunyaminConfig<Logger>,
+): Bunyamin<Logger>;
+export function wrapLogger<Logger extends BunyanLikeLogger>(
+  logger: Logger,
+  options?: Omit<BunyaminConfig<Logger>, 'logger'>,
+): Bunyamin<Logger>;
+export function wrapLogger<Logger extends BunyanLikeLogger>(
+  maybeLogger: any,
+  maybeConfig?: unknown,
 ): Bunyamin<Logger> {
-  return new Bunyamin(options);
+  const logger = (maybeLogger.logger ?? maybeLogger) as Logger;
+  const config = (logger === maybeLogger ? maybeConfig : maybeLogger) as
+    | BunyaminConfig<Logger>
+    | undefined;
+
+  return new Bunyamin({
+    ...config,
+    logger,
+  });
 }


### PR DESCRIPTION
## `wrapLogger(logger[, options])`

Instead of passing `wrapLogger({ logger: createLogger() })` you can use `wrapLogger(createLogger({ ... }))`.

## `noopLogger()`

Useful for conditional usage (e.g. when debugging mode is on).

```js
wrapLogger(process.env.DEBUG === 'true' ? createLogger() : noopLogger())
```
