### PR TITLE
feat: export global instance as default

### DIFF
--- a/src/decorator/Bunyamin.test.ts
+++ b/src/decorator/Bunyamin.test.ts
@@ -24,6 +24,13 @@ describe('Bunyamin', () => {
 
   test('bunyamin.logger', () => {
     expect(bunyamin.logger).toBe(logger);
+
+    bunyamin.logger = new MockLogger();
+    expect(bunyamin.logger).not.toBe(logger);
+
+    const child = bunyamin.child();
+    expect(child.logger).toBe(bunyamin.logger);
+    expect(() => (child.logger = new MockLogger())).toThrow();
   });
 
   test.each(LEVELS)('bunyamin.%s(message)', (level) => {

--- a/src/decorator/Bunyamin.ts
+++ b/src/decorator/Bunyamin.ts
@@ -46,6 +46,14 @@ export class Bunyamin<Logger extends BunyanLikeLogger = BunyanLikeLogger> {
     return this.#shared.logger;
   }
 
+  set logger(logger: Logger) {
+    if (this.#fields) {
+      throw new Error('Cannot change logger of child instance');
+    }
+
+    this.#shared.logger = logger;
+  }
+
   child(overrides?: UserFields): Bunyamin<Logger> {
     const childContext = this.#mergeFields(this.#fields, this.#transformContext(overrides));
     return new Bunyamin(this.#shared, childContext as never);

--- a/src/decorator/BunyaminGlobal.ts
+++ b/src/decorator/BunyaminGlobal.ts
@@ -1,0 +1,6 @@
+import type { Bunyamin } from './Bunyamin';
+import type { BunyanLikeLogger } from './types';
+
+export type BunyaminGlobal = Bunyamin<BunyanLikeLogger> & {
+  setLogger: (logger: BunyanLikeLogger) => void;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
+import { Bunyamin } from './decorator';
+import { noopLogger } from './noopLogger';
+
 export * from './noopLogger';
 export * from './traceEventStream';
 export * from './uniteTraceEvents';
 export * from './wrapLogger';
+
+export default new Bunyamin({ logger: noopLogger() });

--- a/src/noopLogger/noopLogger.ts
+++ b/src/noopLogger/noopLogger.ts
@@ -4,13 +4,15 @@ const noop: any = () => {
   /* no-op */
 };
 
-export function noopLogger(_options?: any): BunyanLikeLogger {
-  return {
-    fatal: noop,
-    error: noop,
-    warn: noop,
-    info: noop,
-    debug: noop,
-    trace: noop,
-  };
+export class NoopLogger implements BunyanLikeLogger {
+  fatal = noop;
+  error = noop;
+  warn = noop;
+  info = noop;
+  debug = noop;
+  trace = noop;
+}
+
+export function noopLogger(_options?: any) {
+  return new NoopLogger();
 }


### PR DESCRIPTION
This feature should be useful for libraries within Bunyamin's ecosystem.

Now `bunyamin` exports a global instance of Bunyamin logger:

```js
import bunyamin from 'bunyamin';

// Hot-swap logger implementation
bunyamin.logger = { /* ... your custom instance ... */ };

const log = bunyamin.child({ cat: 'my-category' });
log.info('Hello, world!');
```

Libraries can use this instance without worrying about where the logs will be written – the final consumer can configure the logs destination and appearance exactly how they want, but this is no longer the concern of intermediate libraries using the logger.
