### PR TITLE
feat: isDebug() helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { BunyanLikeLogger } from './decorator';
 import { Bunyamin } from './decorator';
 import { noopLogger } from './noopLogger';
 
@@ -5,5 +6,6 @@ export * from './noopLogger';
 export * from './traceEventStream';
 export * from './uniteTraceEvents';
 export * from './wrapLogger';
+export * from './is-debug';
 
-export default new Bunyamin({ logger: noopLogger() });
+export default new Bunyamin<BunyanLikeLogger>({ logger: noopLogger() });

--- a/src/is-debug/createIsDebug.test.ts
+++ b/src/is-debug/createIsDebug.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from '@jest/globals';
+import { createIsDebug } from './createIsDebug';
+
+const enabled = (namespace: string, pattern: string) => createIsDebug(pattern)(namespace);
+
+describe('is-debug', function () {
+  it('supports wildcards', function () {
+    const variable = 'b*';
+
+    expect(enabled('bigpipe', variable)).toBe(true);
+    expect(enabled('bro-fist', variable)).toBe(true);
+    expect(enabled('ro-fist', variable)).toBe(false);
+  });
+
+  it('is disabled by default', function () {
+    expect(enabled('bigpipe', '')).toBe(false);
+    expect(enabled('bigpipe', 'bigpipe')).toBe(true);
+  });
+
+  it('can ignore loggers using a -', function () {
+    const DEBUG = 'bigpipe,-primus,sack,-other';
+
+    expect(enabled('bigpipe', DEBUG)).toBe(true);
+    expect(enabled('sack', DEBUG)).toBe(true);
+    expect(enabled('primus', DEBUG)).toBe(false);
+    expect(enabled('other', DEBUG)).toBe(false);
+    expect(enabled('unknown', DEBUG)).toBe(false);
+  });
+
+  it('supports multiple ranges', function () {
+    const DEBUG = 'bigpipe*,primus*';
+
+    expect(enabled('bigpipe:', DEBUG)).toBe(true);
+    expect(enabled('bigpipes', DEBUG)).toBe(true);
+    expect(enabled('primus:', DEBUG)).toBe(true);
+    expect(enabled('primush', DEBUG)).toBe(true);
+    expect(enabled('unknown', DEBUG)).toBe(false);
+  });
+});

--- a/src/is-debug/createIsDebug.ts
+++ b/src/is-debug/createIsDebug.ts
@@ -1,0 +1,31 @@
+export function createIsDebug(namespaces: string) {
+  const skips: RegExp[] = [];
+  const names: RegExp[] = [];
+
+  for (const part of namespaces.split(/[\s,]+/)) {
+    if (!part) {
+      continue;
+    }
+
+    const destination = part[0] === '-' ? skips : names;
+    const pattern = part.replace(/^-/, '').replace(/\*/g, '.*?');
+    destination.push(new RegExp(`^${pattern}$`));
+  }
+
+  return function isDebug(name: string): boolean {
+    // eslint-disable-next-line unicorn/prefer-at
+    if (name[name.length - 1] === '*') {
+      return true;
+    }
+
+    if (skips.some((regex) => regex.test(name))) {
+      return false;
+    }
+
+    if (names.some((regex) => regex.test(name))) {
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/src/is-debug/index.ts
+++ b/src/is-debug/index.ts
@@ -1,0 +1,3 @@
+import { createIsDebug } from './createIsDebug';
+
+export const isDebug = createIsDebug(process.env.DEBUG || '');


### PR DESCRIPTION
Adds `isDebug` helper function, closely following [debug](https://www.npmjs.com/package/debug) logic.

It allows analyzing `$DEBUG` environment variable for presence of a given `namespace`:

```bash
export DEBUG="*,-mycompany-*"

node -p "require('bunyamin').isDebug('test')"
# true

node -p "require('bunyamin').isDebug('mycompany-package1')"
# false
```