### PR TITLE
feat: improved global instance

### DIFF
--- a/src/decorator/Bunyamin.test.ts
+++ b/src/decorator/Bunyamin.test.ts
@@ -31,6 +31,9 @@ describe('Bunyamin', () => {
     const child = bunyamin.child();
     expect(child.logger).toBe(bunyamin.logger);
     expect(() => (child.logger = new MockLogger())).toThrow();
+
+    const immutable = new Bunyamin({ logger, immutable: true });
+    expect(() => (immutable.logger = new MockLogger())).toThrow();
   });
 
   test.each(LEVELS)('bunyamin.%s(message)', (level) => {

--- a/src/decorator/Bunyamin.ts
+++ b/src/decorator/Bunyamin.ts
@@ -1,5 +1,6 @@
 import { deflateCategories, mergeCategories } from './categories';
 import { isActionable, isError, isObject, isPromiseLike } from '../utils';
+import type { ThreadGroupConfig } from '../streams';
 import type { ThreadID } from '../types';
 import type {
   BunyaminLogMethod,
@@ -32,6 +33,7 @@ export class Bunyamin<Logger extends BunyanLikeLogger = BunyanLikeLogger> {
       this.#fields = undefined;
       this.#shared = {
         ...config,
+        threadGroups: config.threadGroups ?? [],
         messageStack: new MessageStack({
           noBeginMessage: config.noBeginMessage,
         }),
@@ -42,13 +44,21 @@ export class Bunyamin<Logger extends BunyanLikeLogger = BunyanLikeLogger> {
     }
   }
 
+  get threadGroups(): ThreadGroupConfig[] {
+    return this.#shared.threadGroups!;
+  }
+
   get logger(): Logger {
     return this.#shared.logger;
   }
 
   set logger(logger: Logger) {
+    if (this.#shared.immutable) {
+      throw new Error('Cannot change a logger of an immutable instance');
+    }
+
     if (this.#fields) {
-      throw new Error('Cannot change logger of child instance');
+      throw new Error('Cannot change a logger of a child instance');
     }
 
     this.#shared.logger = logger;

--- a/src/decorator/BunyaminGlobal.ts
+++ b/src/decorator/BunyaminGlobal.ts
@@ -1,6 +1,0 @@
-import type { Bunyamin } from './Bunyamin';
-import type { BunyanLikeLogger } from './types';
-
-export type BunyaminGlobal = Bunyamin<BunyanLikeLogger> & {
-  setLogger: (logger: BunyanLikeLogger) => void;
-};

--- a/src/decorator/types/BunyaminConfig.ts
+++ b/src/decorator/types/BunyaminConfig.ts
@@ -1,3 +1,4 @@
+import type { ThreadGroupConfig } from '../../streams';
 import type { BunyaminLogRecordFields } from './BunyaminLogRecordFields';
 import type { BunyanLikeLogger } from './BunyanLikeLogger';
 
@@ -6,6 +7,14 @@ export type BunyaminConfig<Logger extends BunyanLikeLogger> = {
    * Underlying logger to be used.
    */
   logger: Logger;
+  /**
+   * Forbids changing the logger after constuction.
+   */
+  immutable?: boolean;
+  /**
+   * Thread groups to be used for grouping log records.
+   */
+  threadGroups?: ThreadGroupConfig[];
   /**
    * Fallback message to be used when there was no previous message
    * passed with {@link BunyaminLogMethod#begin}.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,12 @@ export * from './uniteTraceEvents';
 export * from './wrapLogger';
 export * from './is-debug';
 
-export default new Bunyamin<BunyanLikeLogger>({ logger: noopLogger() });
+const threadGroups: any[] = [];
+export const bunyamin = new Bunyamin<BunyanLikeLogger>({ logger: noopLogger(), threadGroups });
+export const nobunyamin = new Bunyamin<BunyanLikeLogger>({
+  logger: noopLogger(),
+  threadGroups,
+  immutable: true,
+});
+
+export default bunyamin;

--- a/src/streams/bunyan-trace-event/index.ts
+++ b/src/streams/bunyan-trace-event/index.ts
@@ -1,2 +1,3 @@
 export type { TraceEventStreamOptions } from './options';
+export type { ThreadGroupConfig } from './threads';
 export * from './BunyanTraceEventStream';


### PR DESCRIPTION
Adds `bunyamin` and `nobunyamin` named exports.

These root logger instances receive a shared `threadGroups` config option to facilitate `traceEventStream` creation by the end consumer of Bunyan logs. Libraries using `bunyamin` can push their thread groups (id, name, maxConcurrency) to provide a better experience when browsing the final trace log in Chrome Tracing or Perfetto UI.

```js
import bunyamin from 'bunyamin';

bunyamin.threadGroups.push({ id: 'mylib.emitter', displayName: 'Emitter (mylib)' });
```

And then, the final consumer:

```js
import { createLogger } from 'bunyan';
import bunyamin, { traceEventStream } from 'bunyamin';

bunyamin.logger = createLogger({
  name: 'my-app',
  streams: [
    {
      level: 'trace',
      stream: traceEventStream({
        filePath: '/path/to/trace.json',
        loglevel: 'trace',
        threadGroups: [...bunyamin.threadGroups, { id: 'custom-thread' }],
      }),
    }
  ],
});
```