### PR TITLE
fix: sandboxing issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import type { BunyanLikeLogger } from './decorator';
-import { Bunyamin } from './decorator';
-import { noopLogger } from './noopLogger';
+import realm from './realm';
 
 export * from './noopLogger';
 export * from './traceEventStream';
@@ -8,12 +6,7 @@ export * from './uniteTraceEvents';
 export * from './wrapLogger';
 export * from './is-debug';
 
-const threadGroups: any[] = [];
-export const bunyamin = new Bunyamin<BunyanLikeLogger>({ logger: noopLogger(), threadGroups });
-export const nobunyamin = new Bunyamin<BunyanLikeLogger>({
-  logger: noopLogger(),
-  threadGroups,
-  immutable: true,
-});
+export const bunyamin = realm.bunyamin;
+export const nobunyamin = realm.nobunyamin;
 
 export default bunyamin;

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -1,0 +1,31 @@
+import type { BunyanLikeLogger } from './decorator';
+import { Bunyamin } from './decorator';
+import { noopLogger } from './noopLogger';
+
+type Realm = {
+  bunyamin: Bunyamin<BunyanLikeLogger>;
+  nobunyamin: Bunyamin<BunyanLikeLogger>;
+};
+
+function create() {
+  const threadGroups: any[] = [];
+  const bunyamin = new Bunyamin<BunyanLikeLogger>({ logger: noopLogger(), threadGroups });
+  const nobunyamin = new Bunyamin<BunyanLikeLogger>({
+    logger: noopLogger(),
+    threadGroups,
+    immutable: true,
+  });
+
+  return { bunyamin, nobunyamin };
+}
+
+function getCached(): Realm | undefined {
+  return (globalThis as any).__BUNYAMIN__;
+}
+
+function setCached(realm: Realm) {
+  (globalThis as any).__BUNYAMIN__ = realm;
+  return realm;
+}
+
+export default setCached(getCached() ?? create());


### PR DESCRIPTION
When used in Jest, it is quite often that the module gets reset, which means that if someone mutates the logger implementation in its bunyamin client, their mutation could also be reset accidentally.

This is a workaround fix for this issue. Not brilliant, but good enough for now.