### PR TITLE
fix: raise concurrency limit

### DIFF
--- a/src/streams/bunyan-trace-event/options/normalizeOptions.ts
+++ b/src/streams/bunyan-trace-event/options/normalizeOptions.ts
@@ -36,9 +36,9 @@ function validateThreadGroup(threadGroup: ThreadGroupConfig, index: number) {
       );
     }
 
-    if (threadGroup.maxConcurrency > 100_500) {
+    if (threadGroup.maxConcurrency > 1E6) {
       throw new Error(
-        `Max concurrency (${threadGroup.id} -> ${threadGroup.maxConcurrency}) cannot be greater than 100,500`,
+        `Max concurrency (${threadGroup.id} -> ${threadGroup.maxConcurrency}) cannot be greater than 1,000,000`,
       );
     }
   }


### PR DESCRIPTION
It turned out that in some very rare cases, we can exceed the 100,500 ceiling of max concurrent threads, so to be on the safe side, I raised this to 1,000,000.