### PR TITLE
fix: consumer TypeScript error with skipLibCheck: false

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     "trace-event-lib": "^1.3.1"
   },
   "peerDependencies": {
-    "bunyan": "^1.8.15 || ^2.0.0",
-    "@types/bunyan": "^1.8.8"
+    "@types/bunyan": "^1.8.8",
+    "bunyan": "^1.8.15 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "bunyan": {

--- a/src/wrapLogger.ts
+++ b/src/wrapLogger.ts
@@ -1,7 +1,8 @@
 import type { BunyaminConfig, BunyanLikeLogger } from './decorator';
 import { Bunyamin } from './decorator';
 
-export type * from './decorator';
+export * from './decorator/types';
+export type { Bunyamin } from './decorator';
 
 export function wrapLogger<Logger extends BunyanLikeLogger>(
   options: BunyaminConfig<Logger>,


### PR DESCRIPTION
I've noticed that in some projects using `bunyamin`, when `skipLibCheck: false` is configured in `tsconfig.json`, there's a complaint regarding `export type *`.

This pull request should mitigate the said error.