### PR TITLE
feat: add bunyamin.useTransform() for log fields customization

### DIFF
--- a/src/utils/flow.test.ts
+++ b/src/utils/flow.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from '@jest/globals';
+import { flow } from './flow';
+
+const identity = <T>(x: T) => x;
+const addOne = (x: number) => x + 1;
+const double = (x: number) => x * 2;
+const toUpperCase = (string_: string) => string_.toUpperCase();
+const greet = (string_: string) => `Hello, ${string_}`;
+
+describe('flow', () => {
+  test('composes two functions correctly', () => {
+    const doubleAndAddOne = flow(double, addOne);
+
+    expect(doubleAndAddOne(2)).toBe(5); // (2 * 2) + 1 = 5
+    expect(doubleAndAddOne(0)).toBe(1); // (0 * 2) + 1 = 1
+  });
+
+  test('works with different types', () => {
+    const toUpperCaseAndExclaim = flow(toUpperCase, greet);
+
+    expect(toUpperCaseAndExclaim('world')).toBe('Hello, WORLD');
+  });
+
+  test('handles identity functions', () => {
+    const identityFlow = flow(identity, identity);
+
+    expect(identityFlow(42)).toBe(42);
+    expect(identityFlow('foo')).toBe('foo');
+  });
+});

--- a/src/utils/flow.ts
+++ b/src/utils/flow.ts
@@ -1,0 +1,3 @@
+export function flow<T1, T2, R>(f: (x: T1) => T2, g: (x: T2) => R): (x: T1) => R {
+  return (x: T1) => g(f(x));
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './flow';
 export * from './isActionable';
 export * from './isError';
 export * from './isPromiseLike';


### PR DESCRIPTION
Introduce the `useTransform` method to allow users to easily customize and transform log fields before they are passed to the underlying logger.

The `useTransform` method leverages the existing `transformFields` mechanism and provides a convenient way for users to modify log fields. For example, users can now call:

```javascript
bunyamin.useTransform((fields) => ({ ...fields, err: serializeError(fields.err) }))
```

This feature enhances flexibility and enables users to adapt the logging output to their specific needs, such as serializing error objects, adding custom fields, or modifying existing fields.

The `useTransform` method can be chained, allowing users to compose multiple transformation functions. The transformations will be applied in the order they are defined.

```javascript
bunyamin.useTransform((fields) => ({ ...fields, x: 3 }))
bunyamin.useTransform((fields) => ({ ...fields, x: fields.x * 3 }))
// { x: 9 }
```