### PR TITLE
fix: delay thread group registration

### DIFF
--- a/src/decorator/Bunyamin.ts
+++ b/src/decorator/Bunyamin.ts
@@ -4,8 +4,8 @@ import type { ThreadGroupConfig } from '../streams';
 import type { ThreadID } from '../types';
 import { flow, isActionable, isError, isObject, isPromiseLike } from '../utils';
 import type {
-  BunyaminLogMethod,
   BunyaminConfig,
+  BunyaminLogMethod,
   BunyaminLogRecordFields as UserFields,
   BunyanLikeLogger,
   BunyanLogLevel,
@@ -48,7 +48,7 @@ export class Bunyamin<Logger extends BunyanLikeLogger = BunyanLikeLogger> {
 
   /** @deprecated */
   get threadGroups(): ThreadGroupConfig[] {
-    return [];
+    return [...(this.#shared.threadGroups ?? [])];
   }
 
   get logger(): Logger {

--- a/src/decorator/types/BunyaminConfig.ts
+++ b/src/decorator/types/BunyaminConfig.ts
@@ -14,7 +14,7 @@ export type BunyaminConfig<Logger extends BunyanLikeLogger> = {
   /**
    * Thread groups to be used for grouping log records.
    */
-  threadGroups?: ThreadGroupConfig[];
+  threadGroups?: Iterable<ThreadGroupConfig>;
   /**
    * Fallback message to be used when there was no previous message
    * passed with {@link BunyaminLogMethod#begin}.

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-const */
 import { Bunyamin } from './decorator';
 import { noopLogger } from './noopLogger';
 import { isSelfDebug } from './is-debug';
@@ -10,13 +11,22 @@ type Realm = {
 };
 
 function create() {
+  let bunyamin: Bunyamin;
+  let nobunyamin: Bunyamin;
+
   const selfDebug = isSelfDebug();
-  const bunyamin = new Bunyamin({ logger: noopLogger() });
-  const nobunyamin = new Bunyamin({
+  const threadGroups = new ThreadGroups(() => bunyamin);
+
+  bunyamin = new Bunyamin({
     logger: noopLogger(),
-    immutable: true,
+    threadGroups,
   });
-  const threadGroups = new ThreadGroups(bunyamin);
+
+  nobunyamin = new Bunyamin({
+    immutable: true,
+    logger: noopLogger(),
+    threadGroups,
+  });
 
   if (selfDebug) {
     bunyamin.trace({ cat: 'bunyamin' }, 'bunyamin global instance created');

--- a/src/streams/bunyan-trace-event/BunyanTraceEventStream.ts
+++ b/src/streams/bunyan-trace-event/BunyanTraceEventStream.ts
@@ -27,11 +27,9 @@ export class BunyanTraceEventStream extends Transform {
       strict: options.strict ?? false,
       defaultThreadName: options.defaultThreadName ?? 'Main Thread',
       maxConcurrency: options.maxConcurrency ?? 100,
+      // Lazy to add a `NormalizedOptions...` type, so we just cast it here.
+      threadGroups: options.threadGroups as Iterable<ThreadGroupConfig>,
     });
-
-    for (const threadGroup of options.threadGroups) {
-      this.#threadGroupDispatcher.registerThreadGroup(threadGroup as ThreadGroupConfig);
-    }
   }
 
   _transform(

--- a/src/streams/bunyan-trace-event/options/normalizeOptions.ts
+++ b/src/streams/bunyan-trace-event/options/normalizeOptions.ts
@@ -1,5 +1,5 @@
-import type { TraceEventStreamOptions } from './TraceEventStreamOptions';
 import type { ThreadGroupConfig } from '../threads';
+import type { TraceEventStreamOptions } from './TraceEventStreamOptions';
 
 export function normalizeOptions(
   options: TraceEventStreamOptions,
@@ -8,14 +8,16 @@ export function normalizeOptions(
   options.defaultThreadName = options.defaultThreadName ?? 'Main Thread';
   options.maxConcurrency = options.maxConcurrency ?? 100;
   options.strict = options.strict ?? false;
-  options.threadGroups = [...(options.threadGroups ?? [])].map((threadGroup, index) =>
-    typeof threadGroup === 'string'
-      ? {
-          id: threadGroup,
-          displayName: threadGroup,
-        }
-      : validateThreadGroup(threadGroup, index),
-  );
+  options.threadGroups = Array.isArray(options.threadGroups)
+    ? options.threadGroups.map((threadGroup, index) =>
+        typeof threadGroup === 'string'
+          ? {
+              id: threadGroup,
+              displayName: threadGroup,
+            }
+          : validateThreadGroup(threadGroup, index),
+      )
+    : options.threadGroups ?? [];
 
   if (options.maxConcurrency < 1) {
     throw new Error(`maxConcurrency must be at least 1, got ${options.maxConcurrency}`);

--- a/src/streams/bunyan-trace-event/threads/ThreadGroupDispatcher.test.ts
+++ b/src/streams/bunyan-trace-event/threads/ThreadGroupDispatcher.test.ts
@@ -11,10 +11,12 @@ describe('ThreadGroupDispatcher', () => {
       defaultThreadName: 'Main Thread',
       maxConcurrency: 100,
       strict: false,
-    })
-      .registerThreadGroup({ id: 'foo', displayName: 'A' })
-      .registerThreadGroup({ id: 'bar', displayName: 'B', maxConcurrency: 2 })
-      .registerThreadGroup({ id: 'baz', displayName: 'C', maxConcurrency: 3 });
+      threadGroups: [
+        { id: 'foo', displayName: 'A' },
+        { id: 'bar', displayName: 'B', maxConcurrency: 2 },
+        { id: 'baz', displayName: 'C', maxConcurrency: 3 },
+      ],
+    });
   });
 
   it.each(PHASES)('should fallback to 0 for null tid (ph = %j)', (ph) => {
@@ -74,9 +76,12 @@ describe('ThreadGroupDispatcher', () => {
         defaultThreadName: 'Main Thread',
         maxConcurrency: 2,
         strict: true,
-      }).registerThreadGroup({
-        id: 'foo',
-        displayName: 'A',
+        threadGroups: [
+          {
+            id: 'foo',
+            displayName: 'A',
+          },
+        ],
       });
     });
 
@@ -106,9 +111,12 @@ describe('ThreadGroupDispatcher', () => {
         defaultThreadName: 'Main Thread',
         maxConcurrency: 1,
         strict: true,
-      }).registerThreadGroup({
-        id: 'foo',
-        displayName: 'Single Thread',
+        threadGroups: [
+          {
+            id: 'foo',
+            displayName: 'Single Thread',
+          },
+        ],
       });
 
       expect(dispatcher.resolve('B', 'foo')).toBe(1);
@@ -127,9 +135,12 @@ describe('ThreadGroupDispatcher', () => {
         defaultThreadName: 'Main Thread',
         maxConcurrency: 2,
         strict: false,
-      }).registerThreadGroup({
-        id: 'foo',
-        displayName: 'A',
+        threadGroups: [
+          {
+            id: 'foo',
+            displayName: 'A',
+          },
+        ],
       });
     });
 

--- a/src/thread-groups/ThreadGroups.test.ts
+++ b/src/thread-groups/ThreadGroups.test.ts
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
 import { beforeEach, describe, expect, jest, it } from '@jest/globals';
 import type { ThreadGroups } from './ThreadGroups';
 import { wrapLogger } from '../wrapLogger';
 import type { Bunyamin } from '../decorator';
 
 describe('ThreadGroups', () => {
-  let ThreadGroups: new (logger: Bunyamin) => ThreadGroups;
+  let ThreadGroups: typeof import('./ThreadGroups').ThreadGroups;
   let threadGroups: ThreadGroups;
   let isDebug: jest.Mocked<any>;
   let logger: Bunyamin;
@@ -26,7 +27,7 @@ describe('ThreadGroups', () => {
   describe('in regular mode', () => {
     beforeEach(() => {
       isDebug.isSelfDebug.mockReturnValue(false);
-      threadGroups = new ThreadGroups(logger);
+      threadGroups = new ThreadGroups(() => logger);
     });
 
     it('should be empty by default', () => {
@@ -47,7 +48,7 @@ describe('ThreadGroups', () => {
   describe('in debug mode', () => {
     beforeEach(() => {
       isDebug.isSelfDebug.mockReturnValue(true);
-      threadGroups = new ThreadGroups(logger);
+      threadGroups = new ThreadGroups(() => logger);
     });
 
     it('should call logger.trace upon addition', () => {

--- a/src/thread-groups/ThreadGroups.ts
+++ b/src/thread-groups/ThreadGroups.ts
@@ -3,13 +3,13 @@ import type { ThreadGroupConfig } from '../streams';
 import { isSelfDebug } from '../is-debug';
 import { StackTraceError } from '../decorator/StackTraceError';
 
-export class ThreadGroups {
-  readonly #bunyamin: Bunyamin;
+export class ThreadGroups implements Iterable<ThreadGroupConfig> {
   readonly #debugMode = isSelfDebug();
+  readonly #getBunyamin: () => Bunyamin;
   readonly #groups = new Map<string, ThreadGroupConfig>();
 
-  constructor(bunyamin: Bunyamin) {
-    this.#bunyamin = bunyamin;
+  constructor(getBunyamin: () => Bunyamin) {
+    this.#getBunyamin = getBunyamin;
     this.#groups = new Map();
   }
 
@@ -32,7 +32,7 @@ export class ThreadGroups {
 
   #logAddition(group: ThreadGroupConfig, action: string) {
     const { stack } = new StackTraceError();
-    this.#bunyamin.trace(
+    this.#getBunyamin().trace(
       { cat: 'bunyamin' },
       `thread group ${action}: ${group.id} (${group.displayName})\n\n${stack}`,
     );


### PR DESCRIPTION
This PR ensures that you can add thread groups from multiple sources within the first tick.

This is not a great fix, in particular, because the ideal solution would be to register thread groups on the fly whenever you want.

I hope to return to this issue soon, but for now, this should suffice in most cases.